### PR TITLE
Fix/invalid date

### DIFF
--- a/src/tests/Trading212/tradingHistory.js
+++ b/src/tests/Trading212/tradingHistory.js
@@ -631,7 +631,7 @@ const tradingHistory = [
     },
     {
       "Action": "Market buy",
-      "Time": "2021-07-19 13:30:09",
+      "Time": "19/07/2021 13:30",
       "ISIN": "US88160R1014",
       "Ticker": "TSLA",
       "Name": "\"Tesla\"",

--- a/src/tests/misc.test.js
+++ b/src/tests/misc.test.js
@@ -1,9 +1,0 @@
-import { convertDateStringsToDateObjects } from "../misc";
-
-test('able to convert dates in the following format dd/mm/yyyy hh:mm', () => {
-   const objectWithDate = [{ date: '25/03/2003 15:16' }, { date: '20/03/2003 15:16' }];
-   
-   const objectsWithConvertedDates = convertDateStringsToDateObjects(objectWithDate, 'date');
-
-   expect(objectsWithConvertedDates).toEqual([{ date: new Date(2003, 3, 25, 15, 16) }, { date: new Date(2003, 3, 20, 15, 16) }]);
-});

--- a/src/tests/misc.test.js
+++ b/src/tests/misc.test.js
@@ -1,0 +1,9 @@
+import { convertDateStringsToDateObjects } from "../misc";
+
+test('able to convert dates in the following format dd/mm/yyyy hh:mm', () => {
+   const objectWithDate = [{ date: '25/03/2003 15:16' }, { date: '20/03/2003 15:16' }];
+   
+   const objectsWithConvertedDates = convertDateStringsToDateObjects(objectWithDate, 'date');
+
+   expect(objectsWithConvertedDates).toEqual([{ date: new Date('25/03/2003 15:16') }, { date: new Date('20/03/2003 15:16') }]);
+});

--- a/src/tests/misc.test.js
+++ b/src/tests/misc.test.js
@@ -5,5 +5,5 @@ test('able to convert dates in the following format dd/mm/yyyy hh:mm', () => {
    
    const objectsWithConvertedDates = convertDateStringsToDateObjects(objectWithDate, 'date');
 
-   expect(objectsWithConvertedDates).toEqual([{ date: new Date('25/03/2003 15:16') }, { date: new Date('20/03/2003 15:16') }]);
+   expect(objectsWithConvertedDates).toEqual([{ date: new Date(2003, 3, 25, 15, 16) }, { date: new Date(2003, 3, 20, 15, 16) }]);
 });

--- a/src/trading212/transformer.js
+++ b/src/trading212/transformer.js
@@ -1,13 +1,26 @@
 // Converts a complete ISO date string in UTC time, the typical format for transmitting a date in JSON, to a JavaScript Date instance.
 import FiFo from '../calculationsMethods/FiFo';
-import { parseJSON, format } from 'date-fns';
+import { parseJSON, format, parse } from 'date-fns';
 import { getAllYears } from '../misc';
 
 const Trading212 = (function () {
     const actionsDone = [];
 
+    function convertDateToJSONFormat(date) {
+        // TODO specific date conversions should always happen directly in the functional component
+        const dateObject = parse(date, 'dd-MM-yyyy kk:mm', new Date());
+        return JSON.stringify(dateObject);
+    }
+
     function addActions(actions) {
-        actionsDone.push(...actions);
+        const actionsWithConvertedDates = actions.map(action => {
+            if (action.Time.length < 19) {
+                const dateStringWithoutBackslash = action.Time.replaceAll('/', '-');
+                action.Time = convertDateToJSONFormat(dateStringWithoutBackslash);
+            }
+            return action;
+        });
+        actionsDone.push(...actionsWithConvertedDates);
     }
 
     function getActionsWithoutDuplicates(actions) {


### PR DESCRIPTION
Dates like `11/11/2021 20:59` were parsed to an invalid date. Now date strings are directly transformed in the Trading212 function componen to a valid JSON date string.